### PR TITLE
Feat/rate limit configuration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,8 @@ gem "bootsnap", require: false
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin Ajax possible
 gem "rack-cors"
 
+gem 'rack-attack'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -130,6 +130,8 @@ GEM
       nio4r (~> 2.0)
     racc (1.7.3)
     rack (3.0.8)
+    rack-attack (6.7.0)
+      rack (>= 1.0, < 4)
     rack-cors (2.0.1)
       rack (>= 2.0.0)
     rack-session (2.0.0)
@@ -193,6 +195,7 @@ DEPENDENCIES
   debug
   mysql2 (~> 0.5)
   puma (>= 5.0)
+  rack-attack
   rack-cors
   rails (~> 7.1.2)
   tzinfo-data

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,0 +1,78 @@
+class Rack::Attack
+
+  ### Configure Cache ###
+
+  # If you don't want to use Rails.cache (Rack::Attack's default), then
+  # configure it here.
+  #
+  # Note: The store is only used for throttling (not blocklisting and
+  # safelisting). It must implement .increment and .write like
+  # ActiveSupport::Cache::Store
+
+  # Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new 
+
+  ### Throttle Spammy Clients ###
+
+  # If any single client IP is making tons of requests, then they're
+  # probably malicious or a poorly-configured scraper. Either way, they
+  # don't deserve to hog all of the app server's CPU. Cut them off!
+  #
+  # Note: If you're serving assets through rack, those requests may be
+  # counted by rack-attack and this throttle may be activated too
+  # quickly. If so, enable the condition to exclude them from tracking.
+
+  # Throttle all requests by IP (60rpm)
+  #
+  # Key: "rack::attack:#{Time.now.to_i/:period}:req/ip:#{req.ip}"
+  throttle('req/ip', limit: 300, period: 5.minutes) do |req|
+    req.ip # unless req.path.start_with?('/assets')
+  end
+
+  ### Prevent Brute-Force Login Attacks ###
+
+  # The most common brute-force login attack is a brute-force password
+  # attack where an attacker simply tries a large number of emails and
+  # passwords to see if any credentials match.
+  #
+  # Another common method of attack is to use a swarm of computers with
+  # different IPs to try brute-forcing a password for a specific account.
+
+  # Throttle POST requests to /login by IP address
+  #
+  # Key: "rack::attack:#{Time.now.to_i/:period}:logins/ip:#{req.ip}"
+  throttle('logins/ip', limit: 5, period: 20.seconds) do |req|
+    if req.path == '/login' && req.post?
+      req.ip
+    end
+  end
+
+  # Throttle POST requests to /login by email param
+  #
+  # Key: "rack::attack:#{Time.now.to_i/:period}:logins/email:#{normalized_email}"
+  #
+  # Note: This creates a problem where a malicious user could intentionally
+  # throttle logins for another user and force their login requests to be
+  # denied, but that's not very common and shouldn't happen to you. (Knock
+  # on wood!)
+  throttle('logins/email', limit: 5, period: 20.seconds) do |req|
+    if req.path == '/login' && req.post?
+      # Normalize the email, using the same logic as your authentication process, to
+      # protect against rate limit bypasses. Return the normalized email if present, nil otherwise.
+      req.params['email'].to_s.downcase.gsub(/\s+/, "").presence
+    end
+  end
+
+  ### Custom Throttle Response ###
+
+  # By default, Rack::Attack returns an HTTP 429 for throttled responses,
+  # which is just fine.
+  #
+  # If you want to return 503 so that the attacker might be fooled into
+  # believing that they've successfully broken your app (or you just want to
+  # customize the response), then uncomment these lines.
+  # self.throttled_responder = lambda do |env|
+  #  [ 503,  # status
+  #    {},   # headers
+  #    ['']] # body
+  # end
+end


### PR DESCRIPTION
# Description
レートリミットの設定
## Proposed Changes

- [x] Gem rack_attackのインストール
- [x] config/initializers/rack_attack.rbの設定

`config/initializers/rack_attack.rb`の設定は公式ドキュメントにある簡単なおすすめ設定を採用しています。
https://github.com/rack/rack-attack/blob/main/docs/example_configuration.md

開発環境にて`config/initializers/rack_attack.rb`の記述を以下に変更し、
レートリミットが正しく動作しているのか確認しています。
(同一IPアドレスからの全リクエストを5分間に3回までに制限)
```
  throttle('req/ip', limit: 3, period: 5.minutes) do |req|
    req.ip # unless req.path.start_with?('/assets')
  end
```
コンテナを立ち上げた後、下記urlを参考に開発環境でのキャッシュをオンにしました。
https://techracho.bpsinc.jp/hachi8833/2017_03_16/36942
https://techracho.bpsinc.jp/hachi8833/2017_03_16/36942
```
$ rails dev:cache
Development mode is now being cached.
```

ローカルでリロードを繰り返すとrailsの画面が表示されなくなり、
レートリミットが動作していることを確認しました。

<img width="583" alt="image" src="https://github.com/AGO523/engineer-cv-api/assets/120110798/55c76db2-3a62-4e0a-9baf-3fe6e032782a">

```
engineer-cv-api-web-1  | * Inherited tcp://0.0.0.0:3000
engineer-cv-api-web-1  | Use Ctrl-C to stop
engineer-cv-api-web-1  | Started GET "/" for 192.168.65.1 at 2024-01-04 23:38:05 +0900
engineer-cv-api-web-1  |   ActiveRecord::SchemaMigration Load (5.2ms)  SELECT `schema_migrations`.`version` FROM `schema_migrations` ORDER BY `schema_migrations`.`version` ASC
engineer-cv-api-web-1  | Processing by Rails::WelcomeController#index as HTML
engineer-cv-api-web-1  |   Rendering /usr/local/bundle/gems/railties-7.1.2/lib/rails/templates/rails/welcome/index.html.erb
engineer-cv-api-web-1  |   Rendered /usr/local/bundle/gems/railties-7.1.2/lib/rails/templates/rails/welcome/index.html.erb (Duration: 0.8ms | Allocations: 374)
engineer-cv-api-web-1  | Completed 200 OK in 59ms (Views: 12.3ms | ActiveRecord: 0.0ms | Allocations: 7701)
engineer-cv-api-web-1  |
engineer-cv-api-web-1  |
engineer-cv-api-web-1  | Started GET "/" for 192.168.65.1 at 2024-01-04 23:38:07 +0900
engineer-cv-api-web-1  | Processing by Rails::WelcomeController#index as HTML
engineer-cv-api-web-1  |   Rendering /usr/local/bundle/gems/railties-7.1.2/lib/rails/templates/rails/welcome/index.html.erb
engineer-cv-api-web-1  |   Rendered /usr/local/bundle/gems/railties-7.1.2/lib/rails/templates/rails/welcome/index.html.erb (Duration: 0.1ms | Allocations: 13)
engineer-cv-api-web-1  | Completed 200 OK in 2ms (Views: 1.4ms | ActiveRecord: 0.0ms | Allocations: 189)
engineer-cv-api-web-1  |
engineer-cv-api-web-1  |
engineer-cv-api-web-1  | Started GET "/" for 192.168.65.1 at 2024-01-04 23:38:08 +0900
engineer-cv-api-web-1  | Processing by Rails::WelcomeController#index as HTML
engineer-cv-api-web-1  |   Rendering /usr/local/bundle/gems/railties-7.1.2/lib/rails/templates/rails/welcome/index.html.erb
engineer-cv-api-web-1  |   Rendered /usr/local/bundle/gems/railties-7.1.2/lib/rails/templates/rails/welcome/index.html.erb (Duration: 0.1ms | Allocations: 13)
engineer-cv-api-web-1  | Completed 200 OK in 2ms (Views: 1.8ms | ActiveRecord: 0.0ms | Allocations: 188)
engineer-cv-api-web-1  |
engineer-cv-api-web-1  |
engineer-cv-api-web-1  | Started GET "/" for 192.168.65.1 at 2024-01-04 23:38:09 +0900
engineer-cv-api-web-1  | Started GET "/" for 192.168.65.1 at 2024-01-04 23:38:18 +0900
```